### PR TITLE
Add CustomerBundle to repo

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -7,6 +7,10 @@
             "url": "http://github.com/gravity-platform/GravitonRegistryBundle"
         },
         {
+            "type": "vcs",
+            "url": "https://github.com/libgraviton/GravitonCustomerBundle.git"
+        },
+        {
             "type": "package",
             "package": {
                 "name": "libgraviton/swagger-ui",

--- a/satis.json
+++ b/satis.json
@@ -8,7 +8,7 @@
         },
         {
             "type": "vcs",
-            "url": "https://github.com/libgraviton/GravitonCustomerBundle.git"
+            "url": "https://github.com/libgraviton/GravitonTestServicesBundle.git"
         },
         {
             "type": "package",


### PR DESCRIPTION
Please merge libgraviton/GravitonCustomerBundle#1 before merging this. This makes the new bundle available on http://gravity-platform-packages.nova.scapp.io/.