### PR TITLE
Load forked antimattr/mongodb-migrations-bundle into composer repo

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -13,6 +13,17 @@
         {
             "type": "vcs",
             "url": "https://github.com/libgraviton/swagger-ui.git"
+        },
+        {
+            "type":"package",
+            "package": {
+                "name": "antimattr/mongodb-migrations-bundle",
+                "version":"v1.0.1",
+                "dist": {
+                    "url": "https://api.github.com/repos/libgraviton/mongodb-migrations-bundle/zipball/150abde99715673908b6a81be4f8826a4d222c46",
+                    "type": "zip"
+                }
+            }
         }
     ],
     "require": {


### PR DESCRIPTION
I need some way to deploy the changes in antimattr/mongodb-migrations-bundle#2 while I wait for the PR to either get merged or rejected.

I tried using composers [inline alias](https://getcomposer.org/doc/articles/aliases.md) feature but ended up finding that satis does not support it in a useable way.

I also tried using a [`package`](https://getcomposer.org/doc/05-repositories.md#package-2) entry with a `source` entry pointing to the branch we need. Satis doesn't honor that branch and ends up generating really weird URLs for the referenced version.

I the end I realized that the only way to get the overridden version into satis is by referencing a zipball directly in the `dist` object of a `package` entry.

I've solved this in the fastest (and maybe dirtiest) way possible since I still hope that the initially merged PR gets merged by upstream. Deploying the bundle in this matter is only a stop gap measure to ensure that we can move forward without waiting for the pr.

If this works as intended we will only need to change the satis repo and not each and every repo that needs the bundle. This way we can manage the fork centrally and just remove it from the repo as soon as upstream merges the pr. If upstream ends up rejecting the PR, I'll look into different strategies (and probably just replace the bundle fully).

I decided to simply overwrite upstreams `1.0.1` version in an effort to make upgrading this when upstream does a `1.0.2` or `1.1.0` as painless as possible.