### PR TITLE
Fix autoloader type for fork

### DIFF
--- a/satis.json
+++ b/satis.json
@@ -24,7 +24,7 @@
                     "type": "zip"
                 },
                 "autoload": {
-                    "psr-0": { "AntiMattr\\Bundle\\MongoDBMigrationsBundle\\": "" }
+                    "psr-4": { "AntiMattr\\Bundle\\MongoDBMigrationsBundle\\": "" }
                 }
             }
         }


### PR DESCRIPTION
I probably wasn't looking at upstream good enough when I wrote #11. This should now finally work.